### PR TITLE
C API compliance

### DIFF
--- a/src/base.c
+++ b/src/base.c
@@ -317,14 +317,14 @@ static nano_buf sb_any_buf(const SEXP x) {
   
   switch (TYPEOF(x)) {
   case STRSXP:
-    if (XLENGTH(x) == 1 && !ANY_ATTRIB(x)) {
+    if (XLENGTH(x) == 1 && NO_ATTRIB(x)) {
       const char *s = CHAR(*STRING_PTR_RO(x));
       NANO_INIT(&buf, (unsigned char *) s, strlen(s));
       break;
     }
   if (0) {
   case RAWSXP:
-    if (!ANY_ATTRIB(x)) {
+    if (NO_ATTRIB(x)) {
       NANO_INIT(&buf, (unsigned char *) DATAPTR_RO(x), XLENGTH(x));
       break;
     }

--- a/src/secret.c
+++ b/src/secret.c
@@ -252,14 +252,14 @@ static void hash_object(mbedtls_sha3_context *ctx, const SEXP x) {
   
   switch (TYPEOF(x)) {
   case STRSXP:
-    if (XLENGTH(x) == 1 && !ANY_ATTRIB(x)) {
+    if (XLENGTH(x) == 1 && NO_ATTRIB(x)) {
       const char *s = CHAR(*STRING_PTR_RO(x));
       mbedtls_sha3_update(ctx, (uint8_t *) s, strlen(s));
       return;
     }
     break;
   case RAWSXP:
-    if (!ANY_ATTRIB(x)) {
+    if (NO_ATTRIB(x)) {
       mbedtls_sha3_update(ctx, (uint8_t *) DATAPTR_RO(x), (size_t) XLENGTH(x));
       return;
     }

--- a/src/secret.h
+++ b/src/secret.h
@@ -74,8 +74,8 @@ typedef struct nano_buf_s {
 #define SB_INIT_BUFSIZE 4096
 #define SB_SERIAL_THR 134217728
 
-#ifndef ANY_ATTRIB
-#define ANY_ATTRIB(x) (ATTRIB(x) != R_NilValue)
+#ifndef NO_ATTRIB
+#define NO_ATTRIB(x) (ATTRIB(x) == R_NilValue)
 #endif
 #define SB_DATAPTR(x) (void *) DATAPTR_RO(x)
 #define SB_LOGICAL(x) *(int *) DATAPTR_RO(x)

--- a/src/secret2.c
+++ b/src/secret2.c
@@ -396,14 +396,14 @@ static void hash_object(mbedtls_sha256_context *ctx, const SEXP x) {
   
   switch (TYPEOF(x)) {
   case STRSXP:
-    if (XLENGTH(x) == 1 && !ANY_ATTRIB(x)) {
+    if (XLENGTH(x) == 1 && NO_ATTRIB(x)) {
       const char *s = CHAR(*STRING_PTR_RO(x));
       mbedtls_sha256_update(ctx, (uint8_t *) s, strlen(s));
       return;
     }
     break;
   case RAWSXP:
-    if (!ANY_ATTRIB(x)) {
+    if (NO_ATTRIB(x)) {
       mbedtls_sha256_update(ctx, (uint8_t *) DATAPTR_RO(x), (size_t) XLENGTH(x));
       return;
     }

--- a/src/secret3.c
+++ b/src/secret3.c
@@ -206,14 +206,14 @@ static void hash_object(CSipHash *ctx, const SEXP x) {
   
   switch (TYPEOF(x)) {
   case STRSXP:
-    if (XLENGTH(x) == 1 && !ANY_ATTRIB(x)) {
+    if (XLENGTH(x) == 1 && NO_ATTRIB(x)) {
       const char *s = CHAR(*STRING_PTR_RO(x));
       c_siphash_append(ctx, (uint8_t *) s, strlen(s));
       return;
     }
     break;
   case RAWSXP:
-    if (!ANY_ATTRIB(x)) {
+    if (NO_ATTRIB(x)) {
       c_siphash_append(ctx, (uint8_t *) DATAPTR_RO(x), (size_t) XLENGTH(x));
       return;
     }


### PR DESCRIPTION
Fixes #11. Switch use of `ANY_ATTRIB` to `NO_ATTRIB`, which is  defined in a public rather than internal header.