### PR TITLE
Use mkCharLenCE with UTF-8 tag in JSON string decode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # secretbase (development version)
 
 * Speeds up hex string conversion for hash output (`convert = TRUE`).
+* `jsondec()` now tags decoded strings as UTF-8 per RFC 8259.
 
 # secretbase 1.2.1
 

--- a/src/json.c
+++ b/src/json.c
@@ -146,9 +146,8 @@ static SEXP json_parse_string(const char **p, int *err) {
       *d++ = *s++;
     }
   }
-  *d = '\0';
   (*p)++; // skip closing "
-  return Rf_mkString(buf);
+  return Rf_ScalarString(Rf_mkCharLenCE(buf, (int) (d - buf), CE_UTF8));
 }
 
 static SEXP json_parse_number(const char **p, int *err) {

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -418,6 +418,9 @@ test_equal(jsondec('{"a":"\\u00eF"}')[["a"]], "\u00ef") # Mixed case hex
 test_equal(jsondec('{"a":"Hello \\u4e16\\u754c!"}')[["a"]], "Hello \u4e16\u754c!") # Mixed content
 test_equal(jsondec('{"a":"line1\\u000aline2"}')[["a"]], "line1\nline2") # Newline via Unicode
 test_equal(charToRaw(jsondec('{"a":"\\u0001"}')[["a"]])[1], as.raw(1)) # Control char U+0001
+# UTF-8 encoding tag tests (RFC 8259 Section 8):
+test_equal(Encoding(jsondec('{"a":"\\u00e9"}')[["a"]]), "UTF-8") # decoded value tagged UTF-8
+test_equal(Encoding(names(jsondec('{"\\u00e9":"v"}'))), "UTF-8") # decoded key tagged UTF-8
 # UTF-16 surrogate pair tests (characters outside BMP):
 test_equal(jsondec('{"a":"\\uD83D\\uDE00"}')[["a"]], "\U0001F600")
 test_equal(jsondec('{"a":"\\uD83D\\uDCA9"}')[["a"]], "\U0001F4A9")


### PR DESCRIPTION
Replaces `Rf_mkString` in the JSON string decoder with `Rf_mkCharLenCE(buf, d - buf, CE_UTF8)`. Avoids a redundant `strlen` on every decoded string and tags the result as UTF-8, consistent with the JSON encoder and CBOR decoder in this package.